### PR TITLE
Update Heroku remote name in workflow

### DIFF
--- a/.github/workflows/nlp-timeline-gen-workflow.yml
+++ b/.github/workflows/nlp-timeline-gen-workflow.yml
@@ -42,4 +42,4 @@ jobs:
           sudo apt install ruby
           sudo gem install dpl-heroku
       - name: production deploy to Heroku
-        run: dpl --provider=heroku --app=nlp-timeline-gen --api-key=${{ secrets.HEROKU_API_KEY }}
+        run: dpl --provider=heroku --app=nlp-timeline-gen-prod --api-key=${{ secrets.HEROKU_API_KEY }}


### PR DESCRIPTION
Update the Heroku remote name to allow development of a staging pipeline.

Fixes: #26.