### PR TITLE
Change flake8 settings so that all PEP8 violations are flagged up

### DIFF
--- a/scripts/check_py_format.sh
+++ b/scripts/check_py_format.sh
@@ -1,6 +1,3 @@
 #!/usr/bin/env bash
 
-# stop the build if there are Python syntax errors or undefined names
-flake8 --exclude venv,env . --count --select=E9,F63,F7,F82 --show-source --statistics
-# exit-zero treats all errors as warnings
-flake8 --exclude venv,env . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+flake8 --exclude venv,env . --count --max-complexity=10 --max-line-length=127 --statistics

--- a/tests/test_form_data.py
+++ b/tests/test_form_data.py
@@ -1,7 +1,6 @@
 import json
 import os
 from .constants import OK_RESPONSE_CODE
-import pytest
 
 DIRECTORY = 'tests/books'
 

--- a/tests/test_home_page.py
+++ b/tests/test_home_page.py
@@ -1,5 +1,4 @@
 from .constants import OK_RESPONSE_CODE
-import pytest
 
 
 def test_submit_data(client):


### PR DESCRIPTION
Changed flake8 command line flag values in check_py_format.sh so that all PEP8 violations including unnecessary blank lines are flagged up.

I changed the flag values in the flake8 command that we run during the Python test job in our workflow, so that all Python files are checked for all PEP8 violations. I ran the script locally to find and fix any Python style errors such as unnecessary imports.

Fixes: #23 