### PR TITLE
Add python formatting script

### DIFF
--- a/scripts/fix_py_format.sh
+++ b/scripts/fix_py_format.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+autopep8 --in-place --exclude venv,env -a -a -r ./


### PR DESCRIPTION
Add a script to format all python files to follow the PEP8 style guide. This mirrors the checks carried out in check_py_format.sh.

Fixes: #24.