### PR TITLE
Remove json format check from pipeline

### DIFF
--- a/.github/workflows/nlp-timeline-gen-workflow.yml
+++ b/.github/workflows/nlp-timeline-gen-workflow.yml
@@ -15,8 +15,6 @@ jobs:
         run: ./scripts/setup.sh
       - name: Lint python files with flake8
         run: ./scripts/check_py_format.sh
-      - name: Validate JSON files
-        run: ./scripts/check_json_formatting.sh
       - name: Test with pytest
         run: ./scripts/run_py_tests.sh
   heroku-staging-deploy:

--- a/scripts/check_json_formatting.sh
+++ b/scripts/check_json_formatting.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 return_code=0
-for FILE in `ls ./tests/books`
+for FILE in `ls ./tests/books/*.json`
 do
   jq . "tests/books/$FILE"
   exit_code=$?


### PR DESCRIPTION
Since we no longer use json files for test input, we don't need to check their formatting in the pipeline.

Fixes: #47.